### PR TITLE
insertDesignDocument always fails

### DIFF
--- a/stub/CouchbaseBucketManager.class.php
+++ b/stub/CouchbaseBucketManager.class.php
@@ -66,7 +66,7 @@ class CouchbaseBucketManager {
      * @returns true
      */
     public function insertDesignDocument($name, $data) {
-        if ($this->getDesignDocument($name)) {
+        if (array_key_exists('error', $this->getDesignDocument($name))) {
             throw new CouchbaseException('design document already exists');
         }
         return $this->upsertDesignDocument($name, $data);
@@ -126,4 +126,4 @@ class CouchbaseBucketManager {
         $res = $this->_me->http_request(2, 1, $path, NULL, 2);
         return json_decode($res, true);
     }
-} 
+}


### PR DESCRIPTION
When inserting a new design document using ```insertDesignDocument``` method in the **CouchbaseBucketManager.class.php**, it never works because ```getDesignDocument``` method still returns an array when the requested document doesn't exist. 

This is how it's currently done. It always passes since it's checking an array.

```php
if ($this->getDesignDocument($name)) {
    throw new CouchbaseException('design document already exists');
}
```

This pull request is based on the assumption that "_design/{documentName}" rest API either returns an existing design document or returns  the following error response.

```json
{
    "error": "not_found",
    "reason": "missing"
}
```