### PR TITLE
Runs connection shutdown if request exited from fatal error

### DIFF
--- a/couchbase.c
+++ b/couchbase.c
@@ -100,6 +100,14 @@ PHP_MSHUTDOWN_FUNCTION(couchbase)
 	return SUCCESS;
 }
 
+PHP_RSHUTDOWN_FUNCTION(couchbase)
+{
+	if (PG(last_error_message) && PG(last_error_type) == E_ERROR) {
+		couchbase_shutdown_bucket(SHUTDOWN_FUNC_ARGS_PASSTHRU);
+	}
+	return SUCCESS;
+}
+
 PHP_RINIT_FUNCTION(couchbase)
 {
 	
@@ -135,7 +143,7 @@ zend_module_entry couchbase_module_entry = {
 	PHP_MINIT(couchbase),
 	PHP_MSHUTDOWN(couchbase),
 	PHP_RINIT(couchbase),
-	NULL,
+	PHP_RSHUTDOWN(couchbase),
 	NULL,
 #if ZEND_MODULE_API_NO >= 20010901
 	PHP_COUCHBASE_VERSION,


### PR DESCRIPTION
Runs the persistent connection shutdown if the request exited from a fatal error. This resolves issues which can occur if PHP runs out of memory whilst in the SDK as it leaves the lcb object in a weird state.

Some additional checking to see if emalloc suceeded might be also sensible as PHP will only exit from OOM **after** the SDK has finished with the function.